### PR TITLE
fix compile warning

### DIFF
--- a/src/process_operations.cpp
+++ b/src/process_operations.cpp
@@ -50,7 +50,7 @@ class process_operations : public misc{
                     free(data);
                     return NULL;
                 }
-                memcpy(data+offset, &word, sizeof(word));
+                memcpy((uint8_t *)data+offset, &word, sizeof(word));
             }
             return data;
         }


### PR DESCRIPTION
src/process_operations.cpp:48:58: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]